### PR TITLE
fix: Fix khao-image caption spacing

### DIFF
--- a/.changeset/fix-image-caption-spacing.md
+++ b/.changeset/fix-image-caption-spacing.md
@@ -1,0 +1,12 @@
+---
+"@der-reiskoch/khao-ui": patch
+---
+
+Fix khao-image caption spacing
+
+Fixed the caption spacing in khao-image component which was previously set to 0, causing captions to appear directly against the image with no gap.
+
+Changes:
+- Changed --khao-image-caption-spacing from var(--khao-sys-size-regular-0) to var(--khao-sys-size-regular-2)
+- Captions now have proper visual separation from images
+- Spacing is based on the design system's regular spacing scale

--- a/packages/khao-ui/src/components/media/image/Image.svelte
+++ b/packages/khao-ui/src/components/media/image/Image.svelte
@@ -97,7 +97,7 @@
     --khao-image-border-radius: var(--khao-sys-shape-corner-none);
     --khao-image-filter: none;
 
-    --khao-image-caption-spacing: var(--khao-sys-size-regular-0);
+    --khao-image-caption-spacing: var(--khao-sys-size-regular-2);
     --khao-image-caption-color: var(--khao-sys-color-neutral30);
     --khao-image-caption-font-size: var(--khao-sys-size-typography-2);
     --khao-image-caption-line-height: var(--khao-sys-size-typography-3);


### PR DESCRIPTION
Changed caption spacing from 0 to regular-2 spacing token (2x base size). Captions were appearing directly against images with no visual separation.

Changes:
- Updated --khao-image-caption-spacing from var(--khao-sys-size-regular-0) to var(--khao-sys-size-regular-2)
- Provides proper visual separation between image and caption

🤖 Generated with [Claude Code](https://claude.com/claude-code)